### PR TITLE
Resume Extraction Storage & Full Profile Retrieval

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 
 .env
+
+uploads

--- a/server/drizzle/0002_keen_texas_twister.sql
+++ b/server/drizzle/0002_keen_texas_twister.sql
@@ -1,0 +1,69 @@
+CREATE TABLE "awards" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"organization" text NOT NULL,
+	"date" varchar(10) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "certifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"name" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "education" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"institution" text NOT NULL,
+	"degree" text NOT NULL,
+	"start_date" varchar(4) NOT NULL,
+	"end_date" varchar(4) NOT NULL,
+	"gpa" text,
+	"honors" text[]
+);
+--> statement-breakpoint
+CREATE TABLE "languages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"language" text NOT NULL,
+	"proficiency" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "projects" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"technologies_used" text[] NOT NULL,
+	"url" text
+);
+--> statement-breakpoint
+CREATE TABLE "skills" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"type" text NOT NULL,
+	"list" text[] NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "work_experience" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"profile_id" integer NOT NULL,
+	"company" text NOT NULL,
+	"role" text NOT NULL,
+	"start_date" varchar(10) NOT NULL,
+	"end_date" varchar(10) NOT NULL,
+	"responsibilities" text[] NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "full_name" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "email" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "phone_number" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "summary" text;--> statement-breakpoint
+ALTER TABLE "awards" ADD CONSTRAINT "awards_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "certifications" ADD CONSTRAINT "certifications_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "education" ADD CONSTRAINT "education_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "languages" ADD CONSTRAINT "languages_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "skills" ADD CONSTRAINT "skills_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "work_experience" ADD CONSTRAINT "work_experience_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/drizzle/meta/0002_snapshot.json
+++ b/server/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,579 @@
+{
+  "id": "80cc4cf9-7ada-4f02-b7c1-7eadbb4825ec",
+  "prevId": "08368ac3-ab55-46c4-b20a-52cc3c320ff7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.awards": {
+      "name": "awards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "awards_profile_id_profiles_id_fk": {
+          "name": "awards_profile_id_profiles_id_fk",
+          "tableFrom": "awards",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certifications": {
+      "name": "certifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certifications_profile_id_profiles_id_fk": {
+          "name": "certifications_profile_id_profiles_id_fk",
+          "tableFrom": "certifications",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education": {
+      "name": "education",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpa": {
+          "name": "gpa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "honors": {
+          "name": "honors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "education_profile_id_profiles_id_fk": {
+          "name": "education_profile_id_profiles_id_fk",
+          "tableFrom": "education",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "languages_profile_id_profiles_id_fk": {
+          "name": "languages_profile_id_profiles_id_fk",
+          "tableFrom": "languages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "technologies_used": {
+          "name": "technologies_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_profile_id_profiles_id_fk": {
+          "name": "projects_profile_id_profiles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list": {
+          "name": "list",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_profile_id_profiles_id_fk": {
+          "name": "skills_profile_id_profiles_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_experience": {
+      "name": "work_experience",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_experience_profile_id_profiles_id_fk": {
+          "name": "work_experience_profile_id_profiles_id_fk",
+          "tableFrom": "work_experience",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1762832719233,
       "tag": "0001_loose_morgan_stark",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1763506797404,
+      "tag": "0002_keen_texas_twister",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/profile.controller.js
+++ b/server/src/controllers/profile.controller.js
@@ -6,11 +6,11 @@ const getProfile = async (req, res) => {
     const { userId } = req.params;
     const profile = await profileService.getProfileByUserId(Number(userId));
 
-    if (profile.length === 0) {
+    if (!profile) {
       return res.status(404).json({ error: "Profile not found" });
     }
 
-    return res.status(200).json(profile[0]);
+    return res.status(200).json(profile);
   } catch (error) {
     console.error("Error fetching profile:", error);
     return res.status(500).json({ error: error.message });
@@ -70,8 +70,16 @@ export const uploadAndProcessResume = async (req, res) => {
       return res.status(400).json({ error: "No file uploaded" });
     }
 
+    const { userId } = req.params;
     const extractedData = await processResumeFile(req.file);
-    res.json({ success: true, data: extractedData });
+    
+    if (extractedData.error) {
+        return res.status(500).json({ error: extractedData.error });
+    }
+
+    const result = await profileService.saveExtractedResumeData(Number(userId), extractedData);
+
+    res.json({ success: true, data: extractedData, dbResult: result });
   } catch (error) {
     console.error(error);
     res

--- a/server/src/db/schema.js
+++ b/server/src/db/schema.js
@@ -1,34 +1,161 @@
-import { pgTable, serial, text, timestamp, integer } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  integer,
+  varchar
+} from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
+
+/* ---------------------- USERS ---------------------- */
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   name: text('name').notNull(),
   email: text('email').notNull().unique(),
-  createdAt: timestamp('created_at').defaultNow(),
+  createdAt: timestamp('created_at').defaultNow()
 });
+
+/* ---------------------- PROFILES ---------------------- */
 
 export const profiles = pgTable('profiles', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id').notNull().unique().references(() => users.id, { onDelete: 'cascade' }),
+  userId: integer('user_id')
+    .notNull()
+    .unique()
+    .references(() => users.id, { onDelete: 'cascade' }),
+
+  fullName: text('full_name'),
+  email: text('email'),
+  phoneNumber: text('phone_number'),
+  summary: text('summary'),
+
   bio: text('bio'),
   phone: text('phone'),
   location: text('location'),
+
   createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow()
 });
 
-// Relations
+/* ---------------------- SKILLS ---------------------- */
+
+export const skills = pgTable('skills', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  type: text('type').notNull(),      // Technical, Soft, etc.
+  list: text('list').array().notNull() // array of skill strings
+});
+
+/* ---------------------- WORK EXPERIENCE ---------------------- */
+
+export const workExperience = pgTable('work_experience', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  company: text('company').notNull(),
+  role: text('role').notNull(),
+  startDate: varchar('start_date', { length: 10 }).notNull(), // YYYY-MM
+  endDate: varchar('end_date', { length: 10 }).notNull(),     // YYYY-MM or 'Present'
+
+  responsibilities: text('responsibilities').array().notNull() // list of strings
+});
+
+/* ---------------------- EDUCATION ---------------------- */
+
+export const education = pgTable('education', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  institution: text('institution').notNull(),
+  degree: text('degree').notNull(),
+
+  startDate: varchar('start_date', { length: 4 }).notNull(), // YYYY
+  endDate: varchar('end_date', { length: 4 }).notNull(),     // YYYY
+
+  gpa: text('gpa'),
+  honors: text('honors').array() // array of honors strings
+});
+
+/* ---------------------- PROJECTS ---------------------- */
+
+export const projects = pgTable('projects', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+
+  technologiesUsed: text('technologies_used').array().notNull(),
+  url: text('url')
+});
+
+/* ---------------------- CERTIFICATIONS ---------------------- */
+
+export const certifications = pgTable('certifications', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  name: text('name').notNull()
+});
+
+/* ---------------------- AWARDS ---------------------- */
+
+export const awards = pgTable('awards', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  name: text('name').notNull(),
+  organization: text('organization').notNull(),
+  date: varchar('date', { length: 10 }).notNull() // YYYY-MM
+});
+
+/* ---------------------- LANGUAGES ---------------------- */
+
+export const languages = pgTable('languages', {
+  id: serial('id').primaryKey(),
+  profileId: integer('profile_id')
+    .notNull()
+    .references(() => profiles.id, { onDelete: 'cascade' }),
+
+  language: text('language').notNull(),
+  proficiency: text('proficiency').notNull() // Native, Fluent, etc.
+});
+
+/* ---------------------- RELATIONS ---------------------- */
+
 export const usersRelations = relations(users, ({ one }) => ({
   profile: one(profiles, {
     fields: [users.id],
-    references: [profiles.userId],
-  }),
+    references: [profiles.userId]
+  })
 }));
 
-export const profilesRelations = relations(profiles, ({ one }) => ({
+export const profilesRelations = relations(profiles, ({ one, many }) => ({
   user: one(users, {
     fields: [profiles.userId],
-    references: [users.id],
+    references: [users.id]
   }),
+
+  skills: many(skills),
+  workExperience: many(workExperience),
+  education: many(education),
+  projects: many(projects),
+  certifications: many(certifications),
+  awards: many(awards),
+  languages: many(languages)
 }));

--- a/server/src/db/schema.js
+++ b/server/src/db/schema.js
@@ -159,3 +159,52 @@ export const profilesRelations = relations(profiles, ({ one, many }) => ({
   awards: many(awards),
   languages: many(languages)
 }));
+
+export const skillsRelations = relations(skills, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [skills.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const workExperienceRelations = relations(workExperience, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [workExperience.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const educationRelations = relations(education, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [education.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const projectsRelations = relations(projects, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [projects.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const certificationsRelations = relations(certifications, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [certifications.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const awardsRelations = relations(awards, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [awards.profileId],
+    references: [profiles.id],
+  }),
+}));
+
+export const languagesRelations = relations(languages, ({ one }) => ({
+  profile: one(profiles, {
+    fields: [languages.profileId],
+    references: [profiles.id],
+  }),
+}));

--- a/server/src/services/profile.service.js
+++ b/server/src/services/profile.service.js
@@ -1,14 +1,22 @@
 import { db } from "../db/index.js";
-import { profiles, users } from "../db/schema.js";
+import { profiles, users, skills, workExperience, education, projects, certifications, awards, languages } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 
 export const profileService = {
   // Get profile by user ID
   getProfileByUserId: async (userId) => {
-    return await db
-      .select()
-      .from(profiles)
-      .where(eq(profiles.userId, userId));
+    return await db.query.profiles.findFirst({
+      where: eq(profiles.userId, userId),
+      with: {
+        skills: true,
+        workExperience: true,
+        education: true,
+        projects: true,
+        certifications: true,
+        awards: true,
+        languages: true,
+      },
+    });
   },
 
   // Create profile for a user
@@ -84,5 +92,76 @@ export const profileService = {
       .delete(profiles)
       .where(eq(profiles.userId, userId))
       .returning();
+  },
+
+  // Save extracted resume data
+  saveExtractedResumeData: async (userId, extractedData) => {
+    return await db.transaction(async (tx) => {
+      // 1. Create or Update Profile
+      let profileId;
+      const existingProfile = await tx
+        .select()
+        .from(profiles)
+        .where(eq(profiles.userId, userId));
+
+      if (existingProfile.length > 0) {
+        profileId = existingProfile[0].id;
+        await tx
+          .update(profiles)
+          .set({
+            fullName: extractedData.fullName,
+            email: extractedData.email,
+            phoneNumber: extractedData.phoneNumber,
+            summary: extractedData.summary,
+            updatedAt: new Date(),
+          })
+          .where(eq(profiles.id, profileId));
+      } else {
+        const newProfile = await tx
+          .insert(profiles)
+          .values({
+            userId,
+            fullName: extractedData.fullName,
+            email: extractedData.email,
+            phoneNumber: extractedData.phoneNumber,
+            summary: extractedData.summary,
+          })
+          .returning();
+        profileId = newProfile[0].id;
+      }
+
+      // 2. Helper to delete and insert related data
+      const replaceRelatedData = async (table, data) => {
+        await tx.delete(table).where(eq(table.profileId, profileId));
+        if (data && data.length > 0) {
+          const dataWithProfileId = data.map((item) => ({
+            ...item,
+            profileId,
+          }));
+          await tx.insert(table).values(dataWithProfileId);
+        }
+      };
+
+      // 3. Update Related Tables
+      await replaceRelatedData(skills, extractedData.skills);
+      await replaceRelatedData(workExperience, extractedData.workExperience);
+      await replaceRelatedData(education, extractedData.education);
+      await replaceRelatedData(projects, extractedData.projects);
+      
+      // Handle simple string arrays for certifications
+      await tx.delete(certifications).where(eq(certifications.profileId, profileId));
+      if (extractedData.certifications && extractedData.certifications.length > 0) {
+          const certs = extractedData.certifications.map(name => ({
+              name,
+              profileId
+          }));
+          await tx.insert(certifications).values(certs);
+      }
+
+      await replaceRelatedData(awards, extractedData.awards);
+      await replaceRelatedData(languages, extractedData.languages);
+
+      return { message: "Resume data saved successfully", profileId };
+    });
   },
 };


### PR DESCRIPTION
# Feature: Resume Extraction Storage & Full Profile Retrieval

## Summary
This PR implements the functionality to store parsed resume data into the database and retrieve the full user profile with all related associations (skills, experience, education, etc.). It ensures that uploading a resume automatically populates the user's profile and that the profile endpoint returns the complete data graph.

## Changes

### Database ([server/src/db/schema.js](cci:7://file:///d:/Projects/Web-Apps/ats-sync/server/src/db/schema.js:0:0-0:0))
- Added reverse relations for all profile-related tables (`skills`, `workExperience`, `education`, `projects`, `certifications`, `awards`, `languages`) to enable relational queries using Drizzle ORM.

### Services ([server/src/services/profile.service.js](cci:7://file:///d:/Projects/Web-Apps/ats-sync/server/src/services/profile.service.js:0:0-0:0))
- **New Method [saveExtractedResumeData](cci:1://file:///d:/Projects/Web-Apps/ats-sync/server/src/services/profile.service.js:96:2-165:3)**: Implemented a transactional method that:
    - Creates or updates the base user profile.
    - Deletes existing related entries (e.g., old skills).
    - Inserts new related entries derived from the parsed resume.
- **Updated [getProfileByUserId](cci:1://file:///d:/Projects/Web-Apps/ats-sync/server/src/services/profile.service.js:5:2-19:3)**: Refactored to use `db.query.profiles.findFirst` with the `with` option, enabling the retrieval of the profile and all its related child records in a single efficient query.

### Controllers ([server/src/controllers/profile.controller.js](cci:7://file:///d:/Projects/Web-Apps/ats-sync/server/src/controllers/profile.controller.js:0:0-0:0))
- **[uploadAndProcessResume](cci:1://file:///d:/Projects/Web-Apps/ats-sync/server/src/controllers/profile.controller.js:66:0-88:2)**: 
    - Integrated `profileService.saveExtractedResumeData` to persist parsed data.
    - Improved error handling and fixed a bug where the parsed object was being re-parsed as a string.
- **[getProfile](cci:1://file:///d:/Projects/Web-Apps/ats-sync/server/src/controllers/profile.controller.js:3:0-17:2)**: Updated to handle the single object response structure returned by the updated service (previously returned an array).

## Verification
- **Upload Resume**: Send a `POST` request to `/api/v1/profiles/:userId/upload-resume` with a resume file. Confirm that the response contains the saved data and that the database is populated.
- **Get Profile**: Send a `GET` request to `/api/v1/profiles/:userId`. Confirm that the response is a single JSON object containing the profile details and all nested arrays (skills, workExperience, etc.).